### PR TITLE
Add Jest setup and helper test

### DIFF
--- a/__tests__/Chat.test.js
+++ b/__tests__/Chat.test.js
@@ -1,0 +1,6 @@
+const { generateReference } = require('../components/Chat');
+
+test('generateReference returns string ending with -image.png', () => {
+  const ref = generateReference('path/to/image.png');
+  expect(ref).toMatch(/-image\.png$/);
+});

--- a/components/Chat.js
+++ b/components/Chat.js
@@ -8,6 +8,11 @@ import * as Location from 'expo-location';
 import { ref, uploadBytes, getDownloadURL } from 'firebase/storage';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import MapView from 'react-native-maps';
+export const generateReference = (uri) => {
+  const timeStamp = new Date().getTime();
+  const imageName = uri.split("/").pop();
+  return `${timeStamp}-${imageName}`;
+};
 
 const Chat = ({ route, db, storage, isConnected }) => {
   const { name, color } = route.params;
@@ -190,11 +195,6 @@ const Chat = ({ route, db, storage, isConnected }) => {
     });
   };
 
-  const generateReference = (uri) => {
-    const timeStamp = (new Date()).getTime();
-    const imageName = uri.split("/").pop();
-    return `${timeStamp}-${imageName}`;
-  };
 
   const renderCustomActions = (props) => (
     <Actions

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "build": "npx expo export"
+    "build": "npx expo export",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/metro-runtime": "~3.2.1",
@@ -32,7 +33,9 @@
     "react-native-web": "^0.19.12"
   },
   "devDependencies": {
-    "@babel/core": "^7.24.7"
+    "@babel/core": "^7.24.7",
+    "jest": "^29.7.0",
+    "babel-jest": "^29.7.0"
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- configure Jest for the project
- export `generateReference` from `Chat.js`
- add unit test verifying the image reference helper

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c05df5dc8321a72c4ba168f710aa