### PR TITLE
Fix cached message date parsing

### DIFF
--- a/components/Chat.js
+++ b/components/Chat.js
@@ -25,7 +25,16 @@ const Chat = ({ route, db, storage, isConnected }) => {
   const loadCachedMessages = async () => {
     const cachedMessages = await AsyncStorage.getItem('messages');
     if (cachedMessages) {
-      setMessages(JSON.parse(cachedMessages));
+      try {
+        const parsedMessages = JSON.parse(cachedMessages);
+        const messagesWithDates = parsedMessages.map((msg) => ({
+          ...msg,
+          createdAt: msg.createdAt ? new Date(msg.createdAt) : new Date(),
+        }));
+        setMessages(messagesWithDates);
+      } catch (error) {
+        console.log('Failed to load cached messages:', error.message);
+      }
     }
   };
 


### PR DESCRIPTION
## Summary
- parse dates when loading cached messages to avoid invalid timestamps

## Testing
- `npm test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_6863bddcd01c83218e772b9ac5895910